### PR TITLE
Feat/#23 improve trash detection

### DIFF
--- a/Assets/Scenes/Slam_Scene.unity
+++ b/Assets/Scenes/Slam_Scene.unity
@@ -751,8 +751,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   modelAsset: {fileID: 5022602860645237092, guid: 360781be86348d0439f8fa30864adb32, type: 3}
-  ovrCameraRig: {fileID: 0}
-  confidenceThreshold: 0.25
+  ovrCameraRig: {fileID: 1105374041}
+  confidenceThreshold: 0.4
   highlightMaterials:
   - {fileID: 2100000, guid: e801d932da8bb09419372b1666cb1106, type: 2}
   debugMode: 1
@@ -1184,6 +1184,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1088633812}
   m_CullTransparentMesh: 1
+--- !u!114 &1105374041 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3351887280093960702, guid: b4756ccd433775e4c8e5b65bd8a8f638, type: 3}
+  m_PrefabInstance: {fileID: 1299335715}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: df9f338034892c44ebb62d97894772f1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1119661630
 GameObject:
   m_ObjectHideFlags: 0
@@ -1230,6 +1241,63 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   prefabToSpawn: {fileID: 867114091368880605, guid: 65ce602fd629d2f4fbcd1b7d0789d26a, type: 3}
   spawnPoint: {fileID: 1119661631}
+--- !u!1001 &1127261098
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.98
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
+      propertyPath: m_Name
+      value: messy_room
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
 --- !u!1001 &1299335715
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Slam_Scene.unity
+++ b/Assets/Scenes/Slam_Scene.unity
@@ -756,6 +756,7 @@ MonoBehaviour:
   highlightMaterials:
   - {fileID: 2100000, guid: e801d932da8bb09419372b1666cb1106, type: 2}
   debugMode: 1
+  slamModel: {fileID: 919132149155446097, guid: d7ec9564f6eccf04d85c6fb0186c5e75, type: 3}
 --- !u!4 &709663850
 Transform:
   m_ObjectHideFlags: 0
@@ -1241,63 +1242,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   prefabToSpawn: {fileID: 867114091368880605, guid: 65ce602fd629d2f4fbcd1b7d0789d26a, type: 3}
   spawnPoint: {fileID: 1119661631}
---- !u!1001 &1127261098
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
-      propertyPath: m_RootOrder
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.98
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
-      propertyPath: m_Name
-      value: messy_room
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e2de06d2adda9c146ab7cdf0ecb0735e, type: 3}
 --- !u!1001 &1299335715
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Slam/louise/louise.obj.meta
+++ b/Assets/Slam/louise/louise.obj.meta
@@ -32,7 +32,7 @@ ModelImporter:
     extraExposedTransformPaths: []
     extraUserProperties: []
     clipAnimations: []
-    isReadable: 0
+    isReadable: 1
   meshes:
     lODScreenPercentages: []
     globalScale: 1

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -8,8 +8,9 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Slam_Scene.unity
     guid: 82789e9aa3866d44d92584943fae7a56
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/XR_HandTracking_Scene_mini.unity
     guid: a890c5ac751371e48ab1c65937f310d9
   m_configObjects:
+    Unity.XR.Oculus.Settings: {fileID: 11400000, guid: 80f27da0033b14b4fa690f83b11bcc00, type: 2}
     com.unity.xr.management.loader_settings: {fileID: 11400000, guid: 80423b0746c6e1d4d899f9f1294ba087, type: 2}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -141,8 +141,6 @@ PlayerSettings:
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 11400000, guid: da89b37c55c6df34f8d2312f1cf40192, type: 2}
-  - {fileID: 11400000, guid: 80f27da0033b14b4fa690f83b11bcc00, type: 2}
-  - {fileID: -1944268780840188928, guid: 80423b0746c6e1d4d899f9f1294ba087, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR이 어떤 작업을 수행하는지 간단히 설명해주세요 (예: 새로운 캐릭터 추가, UI 수정 등) -->
UV 좌표를 입력받아 SLAM 모델의 메쉬 내 가장 가까운 정점의 3D 위치를 월드 좌표로 변환하는 GetWorldPosFromUV 함수를 추가하고, 감지된 객체 위치를 SLAM 모델의 위치, 회전, 스케일을 반영해 월드 좌표계에 정확히 시각화하도록 수정했습니다.

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #23 

## ⏳ 작업 내용
- GetWorldPosFromUV 함수 추가: UV 좌표를 받아 SLAM 모델 Mesh 내에서 가장 가까운 3D 정점 좌표를 찾아 반환하도록 구현
- SLAM 모델의 현재 위치(Position), 회전(Rotation), 스케일(Scale)을 적용해 감지된 객체의 3D 위치를 실제 월드 좌표계에 맞게 보정
- 감지 결과 시각화 함수(VisualizeDetections)에서 보정된 월드 좌표를 사용해 위치 표시

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- ADB 로그 기준으로는 Quest 3에서도 UV → 3D 변환 결과 좌표는 정상 출력되고 있습니다.
- 다만 실제 화면에서는 객체가 사용자 주변에 몰려 보이는 현상이 발생합니다.
- 이는 구현된 코드상의 문제가 아니라, XR 좌표계 정렬 등 외부 환경 이슈로 판단됩니다.
- 다음 스캔 시에는 정렬 상태를 더 정확히 맞춰보는 방식으로 스캔해봅시다...
