### PR TITLE
Feat/#80 hand trash collision

### DIFF
--- a/Assets/Scenes/Slam_Scene.unity
+++ b/Assets/Scenes/Slam_Scene.unity
@@ -831,6 +831,19 @@ MeshCollider:
   m_Convex: 1
   m_CookingOptions: 30
   m_Mesh: {fileID: -2432090755550338912, guid: 06f2ce5ea66e97e4bbc399b6835d4a67, type: 3}
+--- !u!114 &414444813
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 414444811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd08fa1026a30a142a6a5d4a21ca49fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  className: paper
 --- !u!1 &483087079
 GameObject:
   m_ObjectHideFlags: 0
@@ -1290,7 +1303,6 @@ GameObject:
   m_Component:
   - component: {fileID: 709663850}
   - component: {fileID: 709663856}
-  - component: {fileID: 709663855}
   - component: {fileID: 709663854}
   - component: {fileID: 709663853}
   - component: {fileID: 709663852}
@@ -1374,46 +1386,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   modelAsset: {fileID: 5022602860645237092, guid: 360781be86348d0439f8fa30864adb32, type: 3}
---- !u!114 &709663855
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 709663848}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 88ca023641d91c54e9da4790871df998, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  slamModel: {fileID: 2026718002}
-  calibrationPoints:
-  - name: vinyl
-    uv: {x: 0.36, y: 0.51}
-    worldPos: {x: 1.746, y: -2.13, z: 0.635}
-  - name: glass
-    uv: {x: 0.12, y: 0.5}
-    worldPos: {x: -0.008, y: -2.13, z: 2.24}
-  - name: paper
-    uv: {x: 0.29, y: 0.52}
-    worldPos: {x: 2.411, y: -2.13, z: 2.42}
-  - name: plastic
-    uv: {x: 0.43, y: 0.42}
-    worldPos: {x: 2.63, y: -2.13, z: 1.261}
-  - name: paper2
-    uv: {x: 0.57, y: 0.57}
-    worldPos: {x: 2.5, y: -2.13, z: -0.62}
-  - name: can
-    uv: {x: 0.59, y: 0.46}
-    worldPos: {x: 0.62, y: -2.13, z: 0.45}
-  translation: {x: 0, y: 0, z: 0}
-  rotation: {x: 0, y: 0, z: 0}
-  scale: {x: 1, y: 1, z: 1}
-  debugMode: 1
-  mesh: {fileID: 0}
-  uvs: []
-  vertices: []
-  meshTransform: {fileID: 0}
 --- !u!114 &709663856
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1429,7 +1401,7 @@ MonoBehaviour:
   debugMode: 1
   trashLayerMask:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 512
 --- !u!1 &754948215
 GameObject:
   m_ObjectHideFlags: 0
@@ -1590,6 +1562,19 @@ MeshCollider:
   m_Convex: 1
   m_CookingOptions: 30
   m_Mesh: {fileID: -2432090755550338912, guid: 3a78d4c1656aab64daa48f0d5fb0156f, type: 3}
+--- !u!114 &757313427
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 757313425}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd08fa1026a30a142a6a5d4a21ca49fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  className: can
 --- !u!1001 &828089930
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2097,6 +2082,19 @@ MeshCollider:
   m_Convex: 1
   m_CookingOptions: 30
   m_Mesh: {fileID: -2432090755550338912, guid: dcfe7060aefd7ac49b334f8dbbb2f235, type: 3}
+--- !u!114 &1077658760
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077658758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd08fa1026a30a142a6a5d4a21ca49fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  className: paper
 --- !u!114 &1105374041 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3351887280093960702, guid: b4756ccd433775e4c8e5b65bd8a8f638, type: 3}
@@ -3690,6 +3688,19 @@ MeshCollider:
   m_Convex: 1
   m_CookingOptions: 30
   m_Mesh: {fileID: -2432090755550338912, guid: e63c49888fb125044a0331ed35981057, type: 3}
+--- !u!114 &1884597312
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1884597310}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd08fa1026a30a142a6a5d4a21ca49fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  className: pet
 --- !u!1 &1885363493 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1479451536458054904, guid: ca7259da3631df14d9aa688b92d282e8, type: 3}
@@ -3808,6 +3819,19 @@ MeshCollider:
   m_Convex: 1
   m_CookingOptions: 30
   m_Mesh: {fileID: -2432090755550338912, guid: cfac677ae0fe50f42aab45858c956ca2, type: 3}
+--- !u!114 &1997067395
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1997067393}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd08fa1026a30a142a6a5d4a21ca49fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  className: glass
 --- !u!1 &2013245388
 GameObject:
   m_ObjectHideFlags: 0
@@ -3978,11 +4002,6 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &2026718002 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: -8098169881513260187, guid: 9c31e6f2bae91d94a924f16d96758ca3, type: 3}
-  m_PrefabInstance: {fileID: 828089930}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2099303609 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3351887280100700214, guid: b4756ccd433775e4c8e5b65bd8a8f638, type: 3}
@@ -4088,6 +4107,19 @@ MeshCollider:
   m_Convex: 1
   m_CookingOptions: 30
   m_Mesh: {fileID: -2432090755550338912, guid: 96a07444cd82b0244b3a738fed27d7bd, type: 3}
+--- !u!114 &2115540840
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2115540838}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd08fa1026a30a142a6a5d4a21ca49fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  className: vinyl
 --- !u!1001 &1479451534572691933
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Slam_Scene.unity
+++ b/Assets/Scenes/Slam_Scene.unity
@@ -2436,6 +2436,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b4756ccd433775e4c8e5b65bd8a8f638, type: 3}
+--- !u!1 &1299335716 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3618553690766997812, guid: b4756ccd433775e4c8e5b65bd8a8f638, type: 3}
+  m_PrefabInstance: {fileID: 1299335715}
+  m_PrefabAsset: {fileID: 0}
 --- !u!20 &1299335717 stripped
 Camera:
   m_CorrespondingSourceObject: {fileID: 3351887280101162988, guid: b4756ccd433775e4c8e5b65bd8a8f638, type: 3}
@@ -2446,6 +2451,39 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4752623901141931234, guid: b4756ccd433775e4c8e5b65bd8a8f638, type: 3}
   m_PrefabInstance: {fileID: 1299335715}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1299335719 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1306454593202728594, guid: b4756ccd433775e4c8e5b65bd8a8f638, type: 3}
+  m_PrefabInstance: {fileID: 1299335715}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1299335720
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1299335719}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a32a65f3ecfac0498d678c63b918859, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trashLayerMask:
+    serializedVersion: 2
+    m_Bits: 512
+--- !u!135 &1299335721
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1299335719}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1319092771 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3351887280100535316, guid: b4756ccd433775e4c8e5b65bd8a8f638, type: 3}
@@ -2771,12 +2809,56 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2316449173803222526, guid: b4756ccd433775e4c8e5b65bd8a8f638, type: 3}
   m_PrefabInstance: {fileID: 1299335715}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 1299335716}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1a379f34d4f4f2e408d34f14bfb753ce, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1609360936
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1299335716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a32a65f3ecfac0498d678c63b918859, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trashLayerMask:
+    serializedVersion: 2
+    m_Bits: 512
+--- !u!54 &1609360937
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1299335716}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!135 &1609360938
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1299335716}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1623864911
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/SLAM/DetectionVisualizer.cs
+++ b/Assets/Scripts/SLAM/DetectionVisualizer.cs
@@ -9,68 +9,61 @@ public class DetectionVisualizer : MonoBehaviour
     [SerializeField] private bool showRaycastGizmo = true;
 
     private bool isQuizActive = false;
-
+    private GameObject waitingTrashObject = null;
     private readonly string[] classNames = { "paper", "pack", "can", "glass", "pet", "plastic", "vinyl" };
+
+    public void SetWaitingForRecognition(GameObject trashObj)
+    {
+        waitingTrashObject = trashObj;
+        Debug.Log($"ML 인식 대기 중: {trashObj.name}");
+    }
 
     public void VisualizeDetectionsWithRaycast(List<Detection> detections, Camera camera, Camera vrCamera, LayerMask trashLayerMask)
     {
-        if (isQuizActive || vrCamera == null || detections == null || detections.Count == 0)
+        if (isQuizActive || detections == null || detections.Count == 0 || waitingTrashObject == null)
             return;
 
-        Vector3 origin = vrCamera.transform.position;
-        Vector3 dir = vrCamera.transform.forward;
-
-        if (showRaycastGizmo)
-            Debug.DrawRay(origin, dir * raycastDistance, Color.red, 2f);
-
-        if (Physics.Raycast(origin, dir, out RaycastHit hit, raycastDistance, trashLayerMask))
+        if (debugMode)
         {
-            if (debugMode) Debug.Log($"Raycast 히트: {hit.collider.name}, 위치: {hit.point}");
-
-            string trashClass = GetTrashClassFromObject(hit.collider.gameObject);
-            if (!string.IsNullOrEmpty(trashClass))
+            foreach (var detection in detections)
             {
-                Detection matched = FindMatchingDetection(detections, trashClass);
-                if (matched != null)
-                {
-                    if (debugMode)
-                        Debug.Log($"매칭 감지: {matched.ClassName}, 신뢰도: {matched.Confidence:F2}");
-                    CreateVisualization(matched, hit.point, camera);
-                    isQuizActive = true;
-                }
-                else if (debugMode)
-                    Debug.Log($"감지 결과에 {trashClass} 없음");
+                Debug.Log($"ML 감지: {detection.ClassName}, 신뢰도: {detection.Confidence:F2}");
             }
-            else if (debugMode)
-                Debug.Log($"클래스 없음: {hit.collider.name}");
+        }
+
+        // 가장 높은 신뢰도의 감지 결과 사용
+        Detection bestDetection = null;
+        float maxConfidence = 0f;
+
+        foreach (var detection in detections)
+        {
+            if (detection.Confidence > maxConfidence)
+            {
+                maxConfidence = detection.Confidence;
+                bestDetection = detection;
+            }
+        }
+
+        if (bestDetection != null && bestDetection.Confidence > 0.5f) // 신뢰도 임계값
+        {
+            Debug.Log($"인식된 쓰레기: {bestDetection.ClassName} (신뢰도: {bestDetection.Confidence:F2})");
+
+            Vector3 spawnPos = waitingTrashObject.transform.position;
+            quizManager?.StartQuiz(bestDetection.ClassName, spawnPos);
+
+            isQuizActive = true;
+            waitingTrashObject = null;
         }
         else if (debugMode)
-            Debug.Log("Raycast 히트 없음");
-    }
-
-    private string GetTrashClassFromObject(GameObject obj)
-    {
-        string lowerName = obj.name.ToLower();
-        foreach (var cname in classNames)
-            if (lowerName.Contains(cname)) return cname;
-
-        var trashType = obj.GetComponent<TrashType>();
-        return trashType?.className;
-    }
-
-    private Detection FindMatchingDetection(List<Detection> detections, string targetClass)
-    {
-        return detections.Find(d => d.ClassName == targetClass);
-    }
-
-    private void CreateVisualization(Detection detection, Vector3 hitPoint, Camera camera)
-    {
-        quizManager?.StartQuiz(detection.ClassName, hitPoint);
+        {
+            Debug.Log("신뢰도가 낮아 퀴즈를 시작하지 않음");
+        }
     }
 
     public void OnQuizCompleted()
     {
         isQuizActive = false;
+        waitingTrashObject = null;
         if (debugMode) Debug.Log("퀴즈 완료 – 다음 감지 준비");
     }
 }

--- a/Assets/Scripts/SLAM/HandCollisionDetector.cs
+++ b/Assets/Scripts/SLAM/HandCollisionDetector.cs
@@ -5,11 +5,10 @@ using UnityEngine;
 public class HandCollisionDetector : MonoBehaviour
 {
     [SerializeField] private LayerMask trashLayerMask; // trash
-
     private bool isHoldingTrash = false;
     private GameObject currentTrash = null;
 
-    private void OnTriggerExit(Collider other)
+    private void OnTriggerEnter(Collider other)
     {
         if (((1 << other.gameObject.layer) & trashLayerMask) != 0 && !isHoldingTrash)
         {
@@ -17,10 +16,12 @@ public class HandCollisionDetector : MonoBehaviour
             currentTrash = other.gameObject;
             Debug.Log("손-쓰레기 충돌 인식 " + currentTrash.name);
 
-            TrashRecognitionManager.Instance.OnTrashPicked(currentTrash);
+            // ML 인식 트리거
+            QuizManager.Instance?.TriggerMLRecognition(currentTrash);
         }
     }
-    private void OntriggerExit(Collider other)
+
+    private void OnTriggerExit(Collider other)
     {
         if (other.gameObject == currentTrash)
         {

--- a/Assets/Scripts/SLAM/HandCollisionDetector.cs
+++ b/Assets/Scripts/SLAM/HandCollisionDetector.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HandCollisionDetector : MonoBehaviour
+{
+    [SerializeField] private LayerMask trashLayerMask; // trash
+
+    private bool isHoldingTrash = false;
+    private GameObject currentTrash = null;
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (((1 << other.gameObject.layer) & trashLayerMask) != 0 && !isHoldingTrash)
+        {
+            isHoldingTrash = true;
+            currentTrash = other.gameObject;
+            Debug.Log("손-쓰레기 충돌 인식 " + currentTrash.name);
+
+            TrashRecognitionManager.Instance.OnTrashPicked(currentTrash);
+        }
+    }
+    private void OntriggerExit(Collider other)
+    {
+        if (other.gameObject == currentTrash)
+        {
+            isHoldingTrash = false;
+            currentTrash = null;
+            Debug.Log("손에서 쓰레기 물체 분리됨");
+        }
+    }
+}

--- a/Assets/Scripts/SLAM/HandCollisionDetector.cs.meta
+++ b/Assets/Scripts/SLAM/HandCollisionDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a32a65f3ecfac0498d678c63b918859
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SLAM/QuizManager.cs
+++ b/Assets/Scripts/SLAM/QuizManager.cs
@@ -5,6 +5,8 @@ using UnityEngine.UI;
 
 public class QuizManager : MonoBehaviour
 {
+    public static QuizManager Instance;
+
     [SerializeField] private QuizUIController quizUI;
     [SerializeField] private SlamQuiizUIController quizUII;
     [SerializeField] private PotSpawner potSpawner;
@@ -78,10 +80,34 @@ public class QuizManager : MonoBehaviour
         }}
     };
 
+    private void Awake()
+    {
+        Instance = this;
+    }
+
     private void Start()
     {
         quizUI.Initialize(this);
         StartTimer();
+    }
+
+    // 손 충돌 시 ML 인식 트리거
+    public void TriggerMLRecognition(GameObject trashObj)
+    {
+        Debug.Log($"ML 인식 트리거: {trashObj.name}");
+
+        // DetectionVisualizer에 대기 설정
+        if (detectionVisualizer != null)
+        {
+            detectionVisualizer.SetWaitingForRecognition(trashObj);
+        }
+
+        // TrashDetectorController에 감지 명령
+        var trashDetector = FindObjectOfType<TrashDetectorController>();
+        if (trashDetector != null)
+        {
+            trashDetector.TriggerDetection();
+        }
     }
 
     public void StartQuiz(string className, Vector3 worldPos)
@@ -119,7 +145,6 @@ public class QuizManager : MonoBehaviour
     {
         if (!isTimerRunning) return;
 
-
         timer += Time.deltaTime;
 
         float timeRemaining = Mathf.Max(0f, timeLimitInSeconds - timer);
@@ -139,8 +164,8 @@ public class QuizManager : MonoBehaviour
             {
                 dialogueManager.ShowTimeoutNoticeAndChangeScene(
                     "시간이 초과되었습니다.\n이제 다음 단계로 이동합니다.",
-                    5f, // 메시지를 5초 보여주고
-                    sceneToLoadAfterTimeout // 이후 씬 이동
+                    5f,
+                    sceneToLoadAfterTimeout
                 );
             }
         }
@@ -152,8 +177,8 @@ public class QuizManager : MonoBehaviour
         {
             dialogueManager.ShowTimeoutNoticeAndChangeScene(
                 "시간이 초과되었습니다.\n이제 다음 단계로 이동합니다.",
-                5f, // UI 표시 시간
-                sceneToLoadAfterTimeout // 이동할 씬 이름
+                5f,
+                sceneToLoadAfterTimeout
             );
         }
         else
@@ -168,5 +193,4 @@ public class QuizManager : MonoBehaviour
         int seconds = Mathf.FloorToInt(timeRemaining % 60f);
         timerText.text = $"{minutes:00}:{seconds:00}";
     }
-
 }

--- a/Assets/Scripts/SLAM/TrashDetectorController.cs
+++ b/Assets/Scripts/SLAM/TrashDetectorController.cs
@@ -15,6 +15,7 @@ public class TrashDetectorController : MonoBehaviour
     private Camera vrCamera;
 
     private bool isProcessing = false;
+    private bool shouldDetect = false; // 손 충돌 시에만 감지
 
     void Awake()
     {
@@ -71,9 +72,7 @@ public class TrashDetectorController : MonoBehaviour
 
     private void OnModelLoaded()
     {
-        if (!IsInvoking(nameof(DetectTrash)))
-            InvokeRepeating(nameof(DetectTrash), 3f, 3f);
-        if (debugMode) Debug.Log("TrashDetectorController: 감지 시작");
+        if (debugMode) Debug.Log("TrashDetectorController: 모델 로드 완료, 손 충돌 대기 중");
     }
 
     private void OnModelLoadError(string error)
@@ -81,10 +80,22 @@ public class TrashDetectorController : MonoBehaviour
         Debug.LogError($"TrashDetectorController: 모델 로드 실패 - {error}");
     }
 
+    // 손 충돌 시 호출
+    public void TriggerDetection()
+    {
+
+        if (isProcessing || !modelManager.IsModelLoaded) return;
+
+        shouldDetect = true;
+        DetectTrash();
+    }
+
     private void DetectTrash()
     {
-        if (isProcessing || !modelManager.IsModelLoaded) return;
+        if (isProcessing || !modelManager.IsModelLoaded || !shouldDetect) return;
+
         isProcessing = true;
+        shouldDetect = false;
         StartCoroutine(CaptureAndProcess());
     }
 

--- a/Assets/Scripts/SLAM/TrashRecognitionManager.cs
+++ b/Assets/Scripts/SLAM/TrashRecognitionManager.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TrashRecognitionManager : MonoBehaviour
+{
+    public static TrashRecognitionManager Instance;
+    [SerializeField] private QuizManager quizManager;
+
+    private void Awake()
+    {
+        Instance = this;
+    }
+
+    public void OnTrashPicked(GameObject trashObj)
+    {
+        var trashType = trashObj.GetComponent<TrashType>();
+        if (trashType == null) return;
+
+        string className = trashType.className;
+        Vector3 spawnPos = trashObj.transform.position;
+        quizManager?.StartQuiz(className, spawnPos);
+    }
+}

--- a/Assets/Scripts/SLAM/TrashRecognitionManager.cs.meta
+++ b/Assets/Scripts/SLAM/TrashRecognitionManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a59c672f5a23334794c77ecafc77bb9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR이 어떤 작업을 수행하는지 간단히 설명해주세요 (예: 새로운 캐릭터 추가, UI 수정 등) -->
- 플레이어 손과 쓰레기 오브젝트 간의 충돌 감지 구현
- 이후 쓰레기를 인식 후 퀴즈, 화분 생성까지 기존의 시스템 로직과 연동

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #80 

## ⏳ 작업 내용
- HandCollisionDetector: 플레이어 손-쓰레기 충돌 감지 및 isHoldingTrash, currentTrash 관리
- 충돌 시 ML 인식 트리거 및 이후 퀴즈 흐름 연결
- TrashDetectorController: 손 충돌 시에만 감지되도록 함
- DetectionVisualizer: 인식 결과를 기다렸다가 퀴즈 1회 실행

## 스크린샷
- 유니티 화면
   <img width="1448" height="982" alt="화면 캡처 2025-08-18 183101" src="https://github.com/user-attachments/assets/f17360ed-67db-439e-af06-202317a63105" />
- adb log
   <img width="1920" height="1080" alt="화면 캡처 2025-08-18 181126" src="https://github.com/user-attachments/assets/06a21aad-f658-49ca-afab-1932ee04f753" />
   <img width="1919" height="1078" alt="화면 캡처 2025-08-18 181232" src="https://github.com/user-attachments/assets/5af3ec0d-deb9-46ee-b620-b2aad0412fd1" />

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 유니티 상에선 화분 생성까지 확인했으나, quest에선 panel 문제가 아직 해결이 안 되어서 손-쓰레기 충돌 감지까지 확인함. 추후 리팩토링 예정
