### PR TITLE
[BUG] 퀴즈 UI 내 쓰레기 이미지 업데이트 되도록 수정 #85

### DIFF
--- a/Assets/Scenes/Slam_Scene.unity
+++ b/Assets/Scenes/Slam_Scene.unity
@@ -3414,7 +3414,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   panel: {fileID: 1833759404}
   questionText: {fileID: 205492219}
-  classNameText: {fileID: 1597264573}
+  trashImage: {fileID: 340880589}
+  paperSprite: {fileID: 21300000, guid: cd70895905f082c4a9f67b2a892a347f, type: 3}
+  packSprite: {fileID: 21300000, guid: ad263913d30f6724f91d02b640343d81, type: 3}
+  canSprite: {fileID: 21300000, guid: 33d87fd9475e4ee4f9c1d5ec136ca991, type: 3}
+  glassSprite: {fileID: 21300000, guid: f9218c98bd838744c9104ffb7c5739bf, type: 3}
+  petSprite: {fileID: 21300000, guid: 1e908026d31715148b025c316d2f7fd3, type: 3}
+  plasticSprite: {fileID: 21300000, guid: ebbbe3c8f46547d40b7cc2f690bb359e, type: 3}
+  vinylSprite: {fileID: 21300000, guid: 685033cd07e9b7c428c2d2760bf52d31, type: 3}
 --- !u!114 &1833759407
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/SLAM/QuizUIController.cs
+++ b/Assets/Scripts/SLAM/QuizUIController.cs
@@ -1,33 +1,42 @@
 using UnityEngine;
 using TMPro;
 using System.Collections.Generic;
+using UnityEngine.UI;
 
 public class QuizUIController : MonoBehaviour
 {
     [SerializeField] private GameObject panel;
     [SerializeField] private TMP_Text questionText;
-    [SerializeField] private TMP_Text classNameText;
+    [SerializeField] private Image trashImage;
+
+    [Header("퀴즈 UI용 쓰레기 이미지")]
+    [SerializeField] private Sprite paperSprite;
+    [SerializeField] private Sprite packSprite;
+    [SerializeField] private Sprite canSprite;
+    [SerializeField] private Sprite glassSprite;
+    [SerializeField] private Sprite petSprite;
+    [SerializeField] private Sprite plasticSprite;
+    [SerializeField] private Sprite vinylSprite;
 
     private QuizManager quizManager;
     private string correctAnswer;
     private string currentClassName;
     private Vector3 spawnPosition;
 
-    private Dictionary<string, string> classNameGameText = new Dictionary<string, string>()
-    {
-        { "paper", "종이 아이템 발견!" },
-        { "pack", "팩 아이템 발견!" },
-        { "can", "캔 아이템 발견!" },
-        { "glass", "유리 아이템 발견!" },
-        { "pet", "PET류 아이템 발견!" },
-        { "plastic", "플라스틱 아이템 발견!" },
-        { "vinyl", "비닐 아이템 발견!" }
-    };
+    private Dictionary<string, Sprite> classImageSprites = new Dictionary<string, Sprite>();
 
     public void Initialize(QuizManager manager)
     {
         quizManager = manager;
         panel.SetActive(false);
+
+        classImageSprites["paper"] = paperSprite;
+        classImageSprites["pack"] = packSprite;
+        classImageSprites["can"] = canSprite;
+        classImageSprites["glass"] = glassSprite;
+        classImageSprites["pet"] = petSprite;
+        classImageSprites["plastic"] = plasticSprite;
+        classImageSprites["vinyl"] = vinylSprite;
     }
 
     public void ShowQuiz(string className, string question, string answer, Vector3 worldPos)
@@ -37,7 +46,16 @@ public class QuizUIController : MonoBehaviour
         spawnPosition = worldPos;
 
         questionText.text = question;
-        classNameText.text = classNameGameText.ContainsKey(className) ? classNameGameText[className] : $"🔍 {className} 아이템 발견!";
+        
+        if (trashImage != null && classImageSprites.ContainsKey(className))
+        {
+            trashImage.sprite = classImageSprites[className];
+            trashImage.gameObject.SetActive(true);
+        }
+        else if (trashImage != null)
+        {
+            trashImage.gameObject.SetActive(false);
+        }
 
         panel.SetActive(true);
     }

--- a/Assets/UI/Quiz/glass.png.meta
+++ b/Assets/UI/Quiz/glass.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 12
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -36,13 +36,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -51,9 +51,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -107,7 +107,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/UI/Quiz/pack.png.meta
+++ b/Assets/UI/Quiz/pack.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 12
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -36,13 +36,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -51,9 +51,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -107,7 +107,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/UI/Quiz/pet.png.meta
+++ b/Assets/UI/Quiz/pet.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 12
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -36,13 +36,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -51,9 +51,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -107,7 +107,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/UI/Quiz/plastic.png.meta
+++ b/Assets/UI/Quiz/plastic.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 12
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -36,13 +36,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -51,9 +51,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -107,7 +107,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/UI/Quiz/vinyl.png.meta
+++ b/Assets/UI/Quiz/vinyl.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 12
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -36,13 +36,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -51,9 +51,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -107,7 +107,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -15,7 +15,6 @@
     "com.unity.xr.interaction.toolkit": "2.6.4",
     "com.unity.xr.management": "4.5.1",
     "com.unity.xr.oculus": "3.4.1",
-    "com.unity.xr.openxr": "1.13.2",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -337,18 +337,6 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.xr.openxr": {
-      "version": "1.13.2",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.inputsystem": "1.6.3",
-        "com.unity.xr.core-utils": "2.1.1",
-        "com.unity.xr.management": "4.4.0",
-        "com.unity.xr.legacyinputhelpers": "2.1.2"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.modules.ai": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR이 어떤 작업을 수행하는지 간단히 설명해주세요 (예: 새로운 캐릭터 추가, UI 수정 등) -->
퀴즈 UI에서 쓰레기 종류를 나타내는 이미지가 변경되지 않는 문제를 해결하기 위해 쓰레기 이미지 필드 및 스프라이트 추가, 이미지 변경 로직을 구현하고 에디터에서 UI 이미지와 스프라이트를 연결하도록 수정

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #85 

## ⏳ 작업 내용
- QuizUIController에 퀴즈 UI에 표시될 쓰레기 이미지 필드 추가
- 쓰레기 종류별 Sprite 필드를 추가하고 딕셔너리 초기화
- ShowQuiz 함수에서 className에 맞춰 이미지 변경

## 스크린샷
<img width="919" height="553" alt="화면 캡처 2025-08-24 141442" src="https://github.com/user-attachments/assets/e607886f-5606-40b1-b922-66479430bcf5" />
<img width="915" height="502" alt="화면 캡처 2025-08-24 140915" src="https://github.com/user-attachments/assets/f5c4530e-e52a-41a7-9aec-20c86584179b" />

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 논의하고 싶은 사항:
- 확인 요청:
