### PR TITLE
[REFACTOR] SLAM 씬에서 Raycast 관련 코드 삭제 #87

### DIFF
--- a/Assets/Scripts/SLAM/DetectionVisualizer.cs
+++ b/Assets/Scripts/SLAM/DetectionVisualizer.cs
@@ -5,8 +5,6 @@ public class DetectionVisualizer : MonoBehaviour
 {
     [SerializeField] private bool debugMode = true;
     [SerializeField] private QuizManager quizManager;
-    [SerializeField] private float raycastDistance = 50f;
-    [SerializeField] private bool showRaycastGizmo = true;
 
     private bool isQuizActive = false;
     private GameObject waitingTrashObject = null;
@@ -18,7 +16,7 @@ public class DetectionVisualizer : MonoBehaviour
         Debug.Log($"ML 인식 대기 중: {trashObj.name}");
     }
 
-    public void VisualizeDetectionsWithRaycast(List<Detection> detections, Camera camera, Camera vrCamera, LayerMask trashLayerMask)
+    public void VisualizeDetections(List<Detection> detections, Camera camera, Camera vrCamera)
     {
         if (isQuizActive || detections == null || detections.Count == 0 || waitingTrashObject == null)
             return;

--- a/Assets/Scripts/SLAM/TrashDetectorController.cs
+++ b/Assets/Scripts/SLAM/TrashDetectorController.cs
@@ -6,7 +6,6 @@ using Unity.Barracuda;
 public class TrashDetectorController : MonoBehaviour
 {
     [SerializeField] private bool debugMode = true;
-    [SerializeField] private LayerMask trashLayerMask = -1;
 
     private MLModelManager modelManager;
     private CameraCapture cameraCapture;
@@ -49,8 +48,6 @@ public class TrashDetectorController : MonoBehaviour
             Debug.LogError("TrashDetectorController: VR 카메라를 찾을 수 없습니다.");
         else if (debugMode)
             Debug.Log($"TrashDetectorController: VR 카메라 찾음: {vrCamera.name}");
-
-        trashLayerMask = LayerMask.GetMask("trash");
 
         if (modelManager == null) Debug.LogError("MLModelManager 컴포넌트가 필요합니다!");
         if (cameraCapture == null) Debug.LogError("CameraCapture 컴포넌트가 필요합니다!");
@@ -152,7 +149,7 @@ public class TrashDetectorController : MonoBehaviour
 
             var detections = detectionProcessor.ProcessDetectionResults(outputTensor);
 
-            visualizer.VisualizeDetectionsWithRaycast(detections, camera, vrCamera, trashLayerMask);
+            visualizer.VisualizeDetections(detections, camera, vrCamera);
 
             outputTensor.Dispose();
         }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR이 어떤 작업을 수행하는지 간단히 설명해주세요 (예: 새로운 캐릭터 추가, UI 수정 등) -->
SLAM 씬에서 화분 생성 위치를 결정할 때 기존에는 쓰레기를 향해 Raycast를 쏘는 방식을 사용했으나, 불필요하다고 판단하여 손-쓰레기 충돌 기반 방식으로 변경했습니다. 이에 따라 Raycast 관련 코드를 삭제했습니다.

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #87

## ⏳ 작업 내용
- DetectionVisualizer.cs: Raycast 관련 변수 및 파라미터 삭제
- TrashDetectorController.cs: Raycast 관련 코드 및 변수 삭제

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 논의하고 싶은 사항:  멘토링 후 Raycast 방식이 적합하다고 판단되면 다시 복구 예정
- 확인 요청:
