### PR TITLE
[FEAT] 퀴즈  O/X 답변 컨트롤러 입력 추가 #106

### DIFF
--- a/Assets/Scripts/SLAM/QuizUIController.cs
+++ b/Assets/Scripts/SLAM/QuizUIController.cs
@@ -39,6 +39,22 @@ public class QuizUIController : MonoBehaviour
         classImageSprites["vinyl"] = vinylSprite;
     }
 
+    void Update()
+    {
+        // 퀴즈 UI가 활성화되어 있을 때만 입력 감지
+        if (!panel.activeInHierarchy) return;
+
+        // 오른쪽 컨트롤러만 사용함
+        if (OVRInput.GetDown(OVRInput.Button.Two, OVRInput.Controller.RTouch)) // B버튼 -> O
+        {
+            OnOButtonPressed();
+        }    
+        else if (OVRInput.GetDown(OVRInput.Button.One, OVRInput.Controller.RTouch)) // A버튼 -> X
+        {
+            OnXButtonPressed();
+        }
+    }
+
     public void ShowQuiz(string className, string question, string answer, Vector3 worldPos)
     {
         currentClassName = className;


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR이 어떤 작업을 수행하는지 간단히 설명해주세요 (예: 새로운 캐릭터 추가, UI 수정 등) -->
VR 오른쪽 컨트롤러 버튼으로 퀴즈 O/X 답변을 선택할 수 있도록 구현

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #106 

## ⏳ 작업 내용
- 오른쪽 컨트롤러 B/A 버튼 입력 감지 로직 추가
- 퀴즈 UI 활성화 시에만 입력 감지하도록 최적화

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 논의하고 싶은 사항:
- 확인 요청:

### 참고
- B버튼 (위) → O 답변
- A버튼 (아래) → X 답변
