### PR TITLE
[REFACTOR] 퀴즈 제한 시간 제거 및 paper 타입 성장 단계 수정 #142

### DIFF
--- a/Assets/Prefabs/Flowers/Demo_paper/plantsVase3ver3.prefab
+++ b/Assets/Prefabs/Flowers/Demo_paper/plantsVase3ver3.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &4242100428300728783
+--- !u!1 &404664897698725132
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,37 +8,37 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8253587867517629769}
+  - component: {fileID: 92048284233187915}
   m_Layer: 0
-  m_Name: plantsVase3
+  m_Name: plantsVase3ver3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8253587867517629769
+--- !u!4 &92048284233187915
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4242100428300728783}
+  m_GameObject: {fileID: 404664897698725132}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0.58092433, y: 0.21857671, z: 0.9642259}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7446679211804761637}
-  - {fileID: 1707911785161398164}
+  - {fileID: 1240022637546882822}
+  - {fileID: 4012595959140092624}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1168967524981862527
+--- !u!1001 &3469218389544398139
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 8253587867517629769}
+    m_TransformParent: {fileID: 92048284233187915}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_RootOrder
@@ -46,35 +46,35 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.0004
+      value: 0.0005
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.0004
+      value: 0.0005
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_LocalScale.z
-      value: 0.0004
+      value: 0.0005
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.0015897877
+      value: -0.58092433
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.036701053
+      value: 0.1721233
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.009132008
+      value: -0.9682259
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9996453
+      value: 0.98281735
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.026632538
+      value: -0.1845809
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_LocalRotation.y
@@ -86,7 +86,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -3.052
+      value: -21.273
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -96,35 +96,23 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -6641665339345168992, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.99275094
-      objectReference: {fileID: 0}
-    - target: {fileID: -6641665339345168992, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.12018961
-      objectReference: {fileID: 0}
-    - target: {fileID: -6641665339345168992, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -13.806
-      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
       propertyPath: m_Name
       value: plants1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
---- !u!4 &1707911785161398164 stripped
+--- !u!4 &4012595959140092624 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: b6367d6f6b978094e90e768ca76cf5ae, type: 3}
-  m_PrefabInstance: {fileID: 1168967524981862527}
+  m_PrefabInstance: {fileID: 3469218389544398139}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &3290708129620081323
+--- !u!1001 &6613651324531303304
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 8253587867517629769}
+    m_TransformParent: {fileID: 92048284233187915}
     m_Modifications:
     - target: {fileID: 4735194703025569332, guid: 07cab2717e2f6de4ea57950741d1829e, type: 3}
       propertyPath: m_Name
@@ -136,15 +124,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5403504617471747214, guid: 07cab2717e2f6de4ea57950741d1829e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.0016897876
+      value: -0.58092433
       objectReference: {fileID: 0}
     - target: {fileID: 5403504617471747214, guid: 07cab2717e2f6de4ea57950741d1829e, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.43600106
+      value: -0.21857671
       objectReference: {fileID: 0}
     - target: {fileID: 5403504617471747214, guid: 07cab2717e2f6de4ea57950741d1829e, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.005932008
+      value: -0.9642259
       objectReference: {fileID: 0}
     - target: {fileID: 5403504617471747214, guid: 07cab2717e2f6de4ea57950741d1829e, type: 3}
       propertyPath: m_LocalRotation.w
@@ -176,8 +164,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 07cab2717e2f6de4ea57950741d1829e, type: 3}
---- !u!4 &7446679211804761637 stripped
+--- !u!4 &1240022637546882822 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5403504617471747214, guid: 07cab2717e2f6de4ea57950741d1829e, type: 3}
-  m_PrefabInstance: {fileID: 3290708129620081323}
+  m_PrefabInstance: {fileID: 6613651324531303304}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Flowers/Demo_paper/plantsVase3ver3.prefab.meta
+++ b/Assets/Prefabs/Flowers/Demo_paper/plantsVase3ver3.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f4fda2ccbb9a9794fb485de1f58635e7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Slam_Scene.unity
+++ b/Assets/Scenes/Slam_Scene.unity
@@ -891,7 +891,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   className: paper
-  potSpawnPosition: {x: 0.784, y: 0.018, z: -0.59}
+  potSpawnPosition: {x: 0.2293, y: 0.019, z: -0.466}
 --- !u!1 &454624134
 GameObject:
   m_ObjectHideFlags: 0
@@ -1586,10 +1586,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   quizUI: {fileID: 1833759406}
   potSpawner: {fileID: 1119661632}
-  sceneToLoadAfterTimeout: MiniGame_Bear_Scene
-  timeLimitInSeconds: 180
-  timerText: {fileID: 254199694}
-  dialogueManager: {fileID: 1635961990}
 --- !u!4 &754948217
 Transform:
   m_ObjectHideFlags: 0
@@ -2080,7 +2076,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   className: paper
-  potSpawnPosition: {x: 0.6330001, y: 0.018, z: 0.699}
+  potSpawnPosition: {x: 0.707, y: 0.018, z: 1.17}
 --- !u!114 &1105374041 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3351887280093960702, guid: b4756ccd433775e4c8e5b65bd8a8f638, type: 3}
@@ -2142,7 +2138,7 @@ MonoBehaviour:
       stage1: {fileID: 4735194703025569332, guid: 07cab2717e2f6de4ea57950741d1829e, type: 3}
       stage2: {fileID: 9169834740442585456, guid: 2c44e5fee9664c04f9748e1cbd7c8669, type: 3}
       stage3: {fileID: 2018203606461287635, guid: d8342ce5717eed7428ee2cc0df1c19f9, type: 3}
-      stage4: {fileID: 4242100428300728783, guid: f84d9c6caec39fb439aecce632b38c45, type: 3}
+      stage4: {fileID: 2018203606461287635, guid: d8342ce5717eed7428ee2cc0df1c19f9, type: 3}
   - className: pack
     vaseStages:
       stage1: {fileID: 4735194703025569332, guid: 07cab2717e2f6de4ea57950741d1829e, type: 3}

--- a/Assets/Scripts/SLAM/QuizManager.cs
+++ b/Assets/Scripts/SLAM/QuizManager.cs
@@ -11,18 +11,7 @@ public class QuizManager : MonoBehaviour
     [SerializeField] private PotSpawner potSpawner;
     // [SerializeField] private DetectionVisualizer detectionVisualizer;
 
-    [Header("타이머 설정")]
-    [SerializeField] private string sceneToLoadAfterTimeout;
-    [SerializeField] private float timeLimitInSeconds = 300f;
-    [SerializeField] private Text timerText;
-
-    [SerializeField] private DialogueManager_Slam dialogueManager;
-
-    private float timer = 0f;
-    private bool isTimerRunning = false;
     private bool isQuizEnded = false;
-
-    private int lastDisplayedSeconds = -1;
 
     private Dictionary<string, List<(string, string)>> quizData;
 
@@ -49,8 +38,6 @@ public class QuizManager : MonoBehaviour
         {
             Debug.LogError("QuizManager: QuizUIController가 할당되지 않았습니다");
         }
-
-        StartTimer();
     }
 
     private void InitializeQuizData()
@@ -82,7 +69,7 @@ public class QuizManager : MonoBehaviour
                 ("금속캔에 플라스틱 뚜껑이 붙어 있어도 그대로 배출해도 된다.", "O"),
                 ("금속캔은 이물질이 섞이지 않도록 깨끗이 분리해서 배출해야 한다.", "X"),
                 ("부탄가스 용기는 내용물을 완전히 제거하지 않아도 배출할 수 있다.", "X"),
-                ("가스용기는 통풍이 잘 되는 곳에서 노즐을 눌러 내용물을 완전히 제거한 후 배출해야 한다.", "O")
+                ("가스용기는 통풍이 잘 되는 곳에서\n 노즐을 눌러 내용물을 완전히 제거한 후 배출해야 한다.", "O")
             }},
             { "glass", new List<(string, string)>{
                 ("유리병은 내용물을 비우고 물로 헹군 후 배출해야 한다.", "O"),
@@ -193,69 +180,6 @@ public class QuizManager : MonoBehaviour
         }
 
         Debug.Log("QuizManager: 퀴즈 종료, 다음 쓰레기 인식 가능");
-    }
-
-    private void StartTimer()
-    {
-        timer = 0f;
-        isTimerRunning = true;
-        lastDisplayedSeconds = -1;
-    }
-
-    private void Update()
-    {
-        if (!isTimerRunning) return;
-
-        timer += Time.deltaTime;
-        float timeRemaining = Mathf.Max(0f, timeLimitInSeconds - timer);
-
-        // 1초마다만 UI 업데이트
-        int currentSeconds = Mathf.FloorToInt(timeRemaining);
-        if (currentSeconds != lastDisplayedSeconds)
-        {
-            UpdateTimerUI(timeRemaining);
-            lastDisplayedSeconds = currentSeconds;
-        }
-
-        // 시간 초과 체크
-        if (timer >= timeLimitInSeconds)
-        {
-            OnTimeOut();
-        }
-    }
-
-    private void OnTimeOut()
-    {
-        isTimerRunning = false;
-        isQuizEnded = true;
-
-        // 퀴즈 UI 숨기기
-        if (quizUI != null)
-        {
-            quizUI.HideQuiz();
-        }
-
-        if (dialogueManager != null)
-        {
-            dialogueManager.ShowTimeoutNoticeAndChangeScene(
-                "시간이 초과되었습니다.\n이제 다음 단계로 이동합니다.",
-                5f,
-                sceneToLoadAfterTimeout
-            );
-        }
-        else
-        {
-            Debug.LogWarning("dialogueManager가 설정되지 않았습니다.");
-        }
-    }
-
-    private void UpdateTimerUI(float timeRemaining)
-    {
-        if (timerText == null) return;
-
-        int minutes = Mathf.FloorToInt(timeRemaining / 60f);
-        int seconds = Mathf.FloorToInt(timeRemaining % 60f);
-        timerText.text = $"{minutes:00}:{seconds:00}";
     }
 
     private void OnDestroy()

--- a/Assets/UI/HubUI/multi.png.meta
+++ b/Assets/UI/HubUI/multi.png.meta
@@ -1,0 +1,123 @@
+fileFormatVersion: 2
+guid: 09278f48c35e1f84c8f96cdfdf4be583
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR이 어떤 작업을 수행하는지 간단히 설명해주세요 (예: 새로운 캐릭터 추가, UI 수정 등) -->
퀴즈 제한 시간 삭제하고 paper 타입의 꽃 성장 단계 로직을 3단계에서 2단계로 수정

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #142 

## ⏳ 작업 내용
- 퀴즈 전체 제한 시간 로직 제거
- 3단계 프리팹이 비정상적인 위치에 생성되던 문제로 해당 단계 삭제
- paper 타입의 성장 단계를 2단계까지만 가능하도록 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 논의하고 싶은 사항:
- 확인 요청:
